### PR TITLE
Fix config warnings

### DIFF
--- a/self_registration/apps.py
+++ b/self_registration/apps.py
@@ -1,5 +1,6 @@
 from django.apps import AppConfig
 
 
-class MymoduleConfig(AppConfig):
+class SelfRegistrationConfig(AppConfig):
     name = 'self_registration'
+    default_auto_field = 'django.db.models.AutoField'


### PR DESCRIPTION
Django used to display 9 warnings on each runserver or unit tests, due to a missing line in the module configuration, which is now present